### PR TITLE
ci: update Python versions

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -15,12 +15,12 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9', 'pypy-3.6', 'pypy-3.7']
+        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', 'pypy3.6', 'pypy3.7', 'pypy3.8', 'pypy3.9', 'pypy3.10']
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v4
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
@@ -29,7 +29,7 @@ jobs:
         python -m pip install flake8 pytest
         python setup.py install
     - name: Install pyarrow
-      if: matrix.python-version == '3.8'
+      if: matrix.python-version == '3.11'
       run: |
         python -m pip install pyarrow
     - name: Lint with flake8


### PR DESCRIPTION
It seems that we need some work to support Python 3.12. So this doesn't include '3.12'.