### PR TITLE
enable Dependabot for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
We can automate GitHub Actions update. For example, we can get an automated PR for updating `actions/checkout@v2` to `actions/checkout@v4` with this.